### PR TITLE
Allow LWP::Protocol::PSGI to register multiple PSGI apps under different matching patterns

### DIFF
--- a/t/test.t
+++ b/t/test.t
@@ -1,4 +1,5 @@
 use strict;
+use Carp::Always;
 use Test::More;
 use LWP::UserAgent;
 use LWP::Protocol::PSGI;
@@ -35,10 +36,35 @@ my $psgi_app = sub {
     is $res->content, "query=q=bar";
 }
 
+{
+    my $guard1 = LWP::Protocol::PSGI->register($psgi_app);
+    my $ua  = LWP::UserAgent->new;
+    my $res = $ua->get("http://www.google.com/search?q=bar");
+    is $res->content, "query=q=bar";
+
+    {
+        my $guard2 = LWP::Protocol::PSGI->register(sub { [ 403, [ "Content-Type" => "text/plain" ], [ "Not here" ] ] }, host => "www.yahoo.com");
+        $res = $ua->get("http://www.google.com/search?q=bar");
+        is $res->content, "query=q=bar";
+        $res = $ua->get("http://www.yahoo.com/search?q=bar");
+        is $res->content, "Not here";
+    }
+
+    # guard2 expired
+    $res = $ua->get("http://www.google.com/search?q=bar");
+    is $res->content, "query=q=bar";
+    $res = $ua->get("http://www.yahoo.com/search?q=bar");
+    is $res->content, "query=q=bar";
+}
+
+
+
 sub test_match {
     my($uri, %options) = @_;
-    my $p = LWP::Protocol::PSGI->create(%options);
-    $p->handles(HTTP::Request->new(GET => $uri));
+    my $p = LWP::Protocol::PSGI->register(sub { }, %options);
+    my $ok = LWP::Protocol::PSGI->handles(HTTP::Request->new(GET => $uri));
+    undef $p;
+    return $ok;
 }
 
 ok( test_match 'http://www.google.com/', host => 'www.google.com' );


### PR DESCRIPTION
Ditto. I want to be able to stack different PSGI apps across various places in my test.
