### PR TITLE
Remove needless module dependency

### DIFF
--- a/t/test.t
+++ b/t/test.t
@@ -1,5 +1,4 @@
 use strict;
-use Carp::Always;
 use Test::More;
 use LWP::UserAgent;
 use LWP::Protocol::PSGI;


### PR DESCRIPTION
test.t does not need to import `Carp::Always`.
It may be imported for debugging purpose by @lestrrat.
(Add it to cpanfile, if it is necessary module)
