### PR TITLE
When using '->unregister' we need to clear %orig

### DIFF
--- a/lib/LWP/Protocol/PSGI.pm
+++ b/lib/LWP/Protocol/PSGI.pm
@@ -60,6 +60,7 @@ sub unregister {
         }
     }
     @apps = ();
+    %orig = ();
 }
 
 sub request {

--- a/t/guardless.t
+++ b/t/guardless.t
@@ -1,0 +1,55 @@
+use strict;
+use Test::More;
+use LWP::UserAgent;
+use LWP::Protocol::PSGI;
+use LWP::Simple;
+
+my $psgi_app = sub {
+    my $env = shift;
+    return [
+        200,
+        [
+            "Content-Type", "text/plain",
+            "X-Foo" => "bar",
+        ],
+        [ "query=$env->{QUERY_STRING}" ],
+    ];
+};
+
+LWP::Protocol::PSGI->register($psgi_app);
+
+my $ua  = LWP::UserAgent->new;
+
+sub verify {
+    local $Test::Builder::Level = $Test::Builder::Level + 1;
+
+    my $res = $ua->get("http://www.google.com/search?q=bar");
+    is $res->content, "query=q=bar";
+    is $res->header('X-Foo'), "bar";
+
+    my $body = get "http://www.google.com/?q=x";
+    is $body, "query=q=x";
+}
+
+subtest "when registered" => sub {
+    verify;
+};
+
+LWP::Protocol::PSGI->unregister;
+
+subtest "when unregistered" => sub {
+    my $res = $ua->get("http://www.google.com/search?q=bar");
+    isnt $res->content, "query=q=bar";
+    isnt $res->header('X-Foo'), "bar";
+
+    my $body = get "http://www.google.com/?q=x";
+    isnt $body, "query=q=x";
+};
+
+LWP::Protocol::PSGI->register($psgi_app);
+
+subtest "when reregistered" => sub {
+    verify;
+};
+
+done_testing;


### PR DESCRIPTION
Otherwise, if you attempt to register again, it won't work since
we are no longer intercepting requests and we won't stick ourselves
back into the call chain since %orig has keys.