### PR TITLE
Add travis jobs on ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 sudo: false
 language: perl
+
+arch:
+ - amd
+ - ppc64le
+ 
 perl:
   - "5.22"
 env: AUTOMATED_TESTING=1 AUTHOR_TESTING=1


### PR DESCRIPTION
Hi,
I had added ppc64le(Linux on Power) support on travis-ci in the branch and I believe it is ready for the final review and merge. The travis ci build logs can be verified from the link below.

https://travis-ci.com/github/manish364824/LWP-Protocol-PSGI/builds/199390746

Please have a look.

Regards,
Manish Kumar